### PR TITLE
Fix onboarding config and env vars in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,8 @@ install_nodejs() {
             \. "$HOME/.nvm/nvm.sh"
             
             echo "📦 Downloading and installing Node.js v22..."
-            nvm install 22
+            # install a specific LTS or remove the version suffix if needed
+            nvm install --lts
             
             echo -n "✅ Node.js installation completed! Version: "
             node -v # Should print "v22.17.0".
@@ -59,14 +60,17 @@ fi
 # Configure Claude Code to skip onboarding
 echo "Configuring Claude Code to skip onboarding..."
 node --eval '
-    const homeDir = os.homedir(); 
-    const filePath = path.join(homeDir, ".claude.json");
-    if (fs.existsSync(filePath)) {
-        const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-        fs.writeFileSync(filePath,JSON.stringify({ ...content, hasCompletedOnboarding: true }, 2), "utf-8");
-    } else {
-        fs.writeFileSync(filePath,JSON.stringify({ hasCompletedOnboarding: true }), "utf-8");
-    }'
+  const fs   = require("fs"),
+        os   = require("os"),
+        path = require("path");
+  const fp = path.join(os.homedir(), ".claude.json");
+  let obj = {};
+  if (fs.existsSync(fp)) {
+    obj = JSON.parse(fs.readFileSync(fp, "utf-8"));
+  }
+  obj.hasCompletedOnboarding = true;
+  fs.writeFileSync(fp, JSON.stringify(obj, null, 2), "utf-8");
+'
 
 # Prompt user for API key
 echo "🔑 Please enter your Moonshot API key:"
@@ -109,8 +113,13 @@ else
     # Append new entries
     echo "" >> "$rc_file"
     echo "# Claude Code environment variables" >> "$rc_file"
-    echo "export ANTHROPIC_BASE_URL=https://api.moonshot.cn/anthropic/" >> "$rc_file"
-    echo "export ANTHROPIC_API_KEY=$api_key" >> "$rc_file"
+    if [ "$current_shell" = fish ]; then
+      echo "set -Ux ANTHROPIC_BASE_URL https://api.moonshot.cn/anthropic/" >> "$rc_file"
+      echo "set -Ux ANTHROPIC_API_KEY '$api_key'"                  >> "$rc_file"
+    else
+      echo "export ANTHROPIC_BASE_URL=https://api.moonshot.cn/anthropic/" >> "$rc_file"
+      echo "export ANTHROPIC_API_KEY='$api_key'"                         >> "$rc_file"
+    fi
     echo "✅ Environment variables added to $rc_file"
 fi
 


### PR DESCRIPTION
## Summary
- install Node via LTS to avoid fixed version
- simplify onboarding setup script in Node
- set env vars differently when using fish shell

## Testing
- `bash -n install.sh`
